### PR TITLE
[FIX] no sound after fade out in FF.

### DIFF
--- a/imospc.js
+++ b/imospc.js
@@ -1296,7 +1296,7 @@
 			timeCorrectionFactor = -1 / 0; // -Infinity
 			_isPaused = 0;
 			
-			fadeGain.gain['value'] = 1;
+			fadeGain.gain.setValueAtTime(1, 0); // FF bug; setting gain.['value'] does nothing after linearRampToValueAtTime()
 			outputNode = audioContext.createScriptProcessor(BUFFER_LENGTH, 0, 2);
 			outputNode['onaudioprocess'] = processAudio;
 			outputNode.connect(fadeGain);


### PR DESCRIPTION
This fixes the problem below.

**Steps to reproduce**
- Use firefox (I use 57.0 (64-bit) under Fedora Linux)
- Let a tune play until fade out finishes and player stops
- Play again.

**Actual result**
- No sound

**Expected**
- Sound as usual

Details:
This does not occur on Chrome.
The problem does not occur if `linearRampToValueAtTime()` is not called. But then, there's no fade out ;)